### PR TITLE
Accelerate Area fill operations.

### DIFF
--- a/src/screen.c
+++ b/src/screen.c
@@ -89,7 +89,7 @@ ULONG rassize;
 struct AreaInfo areainfo;
 UBYTE *areabuf;
 #define MAXVEC 80
-
+#define AREABUF_SIZE 8*MAXVEC
 /**
  * screen_init() - Set up the screen
  */
@@ -123,7 +123,7 @@ void screen_init(void)
     myWindow->RPort->TmpRas = &tmpras;
   }
   
-  if(areabuf = AllocMem(8*MAXVEC,MEMF_CLEAR))
+  if(areabuf = AllocMem(AREABUF_SIZE,MEMF_CLEAR))
   {
       InitArea(&areainfo,areabuf,MAXVEC);
       myWindow->RPort->AreaInfo = &areainfo;
@@ -425,6 +425,12 @@ void screen_done(void)
     CloseFont(platoUserFont);
   
   if (myWindow)
+    /* deallocate tmpras and areainfo */
+    myWindow->RPort->TmpRas = 0L;
+    FreeMem(tmpbuf,(long)rassize);
+    myWindow->RPort->AreaInfo = 0L;
+    FreeMem(areabuf,(long)AREABUF_SIZE);
+    /* Now we can safely close the window */  
     CloseWindow(myWindow);
   if (myScreen)
     CloseScreen(myScreen);

--- a/src/screen.c
+++ b/src/screen.c
@@ -78,6 +78,18 @@ struct TextAttr platouser_ta = {"PLATOUser.font",12,0,0};
 struct TextFont* platoFont;
 struct TextFont* platoUserFont;
 
+/* All of this is needed if we don't want area fills that are slower than
+ * grandma on Nyquil. 
+ * The TLDR; is the RastPort needs some scratch space for certain graphics
+ * primitives to work well.
+ */
+struct TmpRas tmpras;
+UBYTE *tmpbuf;
+ULONG rassize;
+struct AreaInfo areainfo;
+UBYTE *areabuf;
+#define MAXVEC 400
+
 /**
  * screen_init() - Set up the screen
  */
@@ -103,7 +115,21 @@ void screen_init(void)
 
   if (!myWindow)
     done();
+  /* Initilize scratch space for area fill primitives */
+  rassize = RASSIZE(myWindow->GZZWidth,myWindow->GZZHeight);
+  if(tmpbuf = AllocMem(rassize,MEMF_CHIP|MEMF_CLEAR))
+  {
+    InitTmpRas(&tmpras,tmpbuf,rassize);
+    myWindow->RPort->TmpRas = &tmpras;
+  }
+  
+  if(areabuf = AllocMem(5*MAXVEC,MEMF_CLEAR))
+  {
+      InitArea(&areainfo,areabuf,MAXVEC);
+      myWindow->RPort->AreaInfo = &areainfo;
+  }
 
+  /* end of scratch space init XXX! add error checking */
   platoFont=OpenDiskFont(&plato_ta);
 
   if (!platoFont)

--- a/src/screen.c
+++ b/src/screen.c
@@ -88,7 +88,7 @@ UBYTE *tmpbuf;
 ULONG rassize;
 struct AreaInfo areainfo;
 UBYTE *areabuf;
-#define MAXVEC 400
+#define MAXVEC 80
 
 /**
  * screen_init() - Set up the screen
@@ -123,7 +123,7 @@ void screen_init(void)
     myWindow->RPort->TmpRas = &tmpras;
   }
   
-  if(areabuf = AllocMem(5*MAXVEC,MEMF_CLEAR))
+  if(areabuf = AllocMem(8*MAXVEC,MEMF_CLEAR))
   {
       InitArea(&areainfo,areabuf,MAXVEC);
       myWindow->RPort->AreaInfo = &areainfo;

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -72,7 +72,7 @@ static unsigned char TAB_0_25[]={0,5,10,15,20,25};
 static unsigned char pix_cnt;
 static unsigned char curr_word;
 static unsigned char u,v;
-unsigned char* fontm23;
+extern unsigned char* fontm23;
 
 /**
  * Initialize terminal state


### PR DESCRIPTION
After looking at the Amiga docs I found out we could speed up area fill operations by allocating two buffers and associating them with the rastport of our window. 

This is based on

http://thomas-rapp.homepage.t-online.de/examples/piechart.c

and the AmigaOS area fill docs at
http://wiki.amigaos.net/wiki/Graphics_Primitives#RastPort_Area-fill_Information

