### PR TITLE
Fix help keys menu close.

### DIFF
--- a/src/help.h
+++ b/src/help.h
@@ -17,11 +17,6 @@ void help_keys_show(void);
 
 
 /**
- * Key help main
- */
-void help_keys_main(void);
-
-/**
  * Help done.
  */
 void help_done(void);

--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -56,10 +56,18 @@ void keyboard_main(void)
   UWORD subNum;
   struct MenuItem *item;
 
-  help_keys_main();
 
   while (intuition_msg = (struct IntuiMessage *) GetMsg(myWindow->UserPort))
     {
+      if (intuition_msg->Class == IDCMP_CLOSEWINDOW) {
+          struct Window *tmp;
+          extern struct Window *windowHelpKeys;
+          tmp = intuition_msg->IDCMPWindow;
+          ReplyMsg((struct Message *) intuition_msg);
+          if(tmp == windowHelpKeys) /* Oh, hey it's our help window, close it */
+              help_done();
+          continue; /* Once we've replied we can't do anything else with the struct */
+      }
       if (intuition_msg->Class == VANILLAKEY)
 	{
 	  if (intuition_msg->Qualifier & IEQUALIFIER_RCOMMAND)

--- a/src/screen.c
+++ b/src/screen.c
@@ -27,7 +27,10 @@
 #include "protocol.h"
 #include "scale.h"
 #include "font.h"
-
+#ifdef __VBCC__
+#undef NULL
+#define NULL 0L
+#endif
 unsigned char CharWide=8;
 unsigned char CharHigh=16;
 unsigned char screen_mode;
@@ -220,7 +223,7 @@ void screen_about(void)
       15,      /* LedtEdge, 15 pixels out. */
       39,       /* TopEdge, 5 lines down. */
       NULL,    /* ITextFont, default font. */
-      "    and Bill Schaub", /* IText, the body text. */
+      "    and Willaim Schaub", /* IText, the body text. */
       NULL,
     };
 

--- a/src/screen.c
+++ b/src/screen.c
@@ -223,7 +223,7 @@ void screen_about(void)
       15,      /* LedtEdge, 15 pixels out. */
       39,       /* TopEdge, 5 lines down. */
       NULL,    /* ITextFont, default font. */
-      "    and Willaim Schaub", /* IText, the body text. */
+      "    and William Schaub", /* IText, the body text. */
       NULL,
     };
 


### PR DESCRIPTION
In oder to process IDCMP events correctly for the help keys window
we have to do some special plumbing in order to share the UserPort and
events between both of our windows. This allows us to just have one
event loop and process the events immediately.

This is accomplished by the following steps:

Alocation:
1) set up the new window structure with NULL for the events field

2) once we have our Window structure set it's ->UserPort to = the main
   window's UserPort

3) call ModifyIDCMP(helpwindowptr,IDCMP_CLOSEWINDOW) This will
   tell intuition to listen for the close window gadget. However it will
   not attempt to open a new UserPort for that window because UserPort
   is not null at this point.

4) Profit! we now have events for both windows on the same UserPort.

Tear down:
1) Stop multitasking with Forbid().

2) Swallow up all remaining messages for the window we are about to
   kill.

3) *IMPORTANT* assign NULL to the help window's ->UserPort or the next
   step will close our main UserPort and crash the system on the next
   event loop.

4) call ModifyIDCMP(helpwindowptr,0L); to tell intuition to stop sending
   events.

5) Permit() to re-enable multitasking.

6) Finally close the window.