### PR TITLE
Obey settings to close the workbench or disable paint.

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -27,7 +27,6 @@
 
 unsigned char read_io_active=false;
 
-extern ConfigInfo config;
 extern void done(void);
 
 MySer* ms;

--- a/src/prefs.h
+++ b/src/prefs.h
@@ -18,6 +18,8 @@ typedef struct _configInfo
   unsigned char close_workbench;      /* Close the Workbench? */
 } ConfigInfo;
 
+extern ConfigInfo config;
+
 /**
  * prefs_open() - Open preferences file
  */


### PR DESCRIPTION
Implements the following preferences settings:

 * paint_enabled
   We don't do any areafill allocations/deallocations if this is 0.
   In addition screen_paint will simply return without doing anything.

 * close_workbench
   if set to 1 we attempt to close the workbench and reopen it on exit.
   regardless of this setting we still attempt a close if low free
   chipram is detected.

I've also moved the extern declaration of config to prefs.h for the
purposes of DRY.