### PR TITLE
Forgot to remove platoBoldUserFont causing crash.

### DIFF
--- a/src/screen.c
+++ b/src/screen.c
@@ -579,6 +579,7 @@ void screen_done(void)
   RemFont(&platoFont);
   RemFont(&platoBoldFont);
   RemFont(&platoUserFont);
+  RemFont(&platoBoldUserFont);
   
   if (myWindow)
     {


### PR DESCRIPTION
We forgot to remove platoBoldUserFont on exit causing a crash
the next time we start platoterm and right click.