### PR TITLE
Compat/wb13 menu and serial

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -233,14 +233,26 @@ void io_done(void)
       // Abort any pending I/O transactions.
       if (ms->writeio != NULL)
 	{
-	  AbortIO((struct IORequest *)ms->writeio);
-	  WaitIO((struct IORequest *)ms->writeio);
+      /* We don't want to chance a hang on WaitIO so only
+       * AbortIO if we have to 
+       */
+      if(!(CheckIO((struct IORequest *)ms->writeio)))
+      {
+          AbortIO((struct IORequest *)ms->writeio);
+          WaitIO((struct IORequest *)ms->writeio);
+      }
 	}
       
       if (ms->readio != NULL)
 	{
-	  AbortIO((struct IORequest *)ms->readio);
-	  WaitIO((struct IORequest *)ms->readio);
+      /* We don't want to chance a hang on WaitIO so only
+       * AbortIO if we have to 
+       */
+      if(!(CheckIO((struct IORequest *)ms->readio)))
+      {
+          AbortIO((struct IORequest *)ms->readio);
+          WaitIO((struct IORequest *)ms->readio);
+      }
 	}
 
       // Close device

--- a/src/menu.c
+++ b/src/menu.c
@@ -211,7 +211,7 @@ void menu_toggle_plato_mode(unsigned char toggle)
     itemPLATOMode.Flags=ITEMTEXT|ITEMENABLED|HIGHCOMP|COMMSEQ|MENUTOGGLE|CHECKIT|CHECKED;
   else
     itemPLATOMode.Flags=ITEMTEXT|ITEMENABLED|HIGHCOMP|COMMSEQ|MENUTOGGLE|CHECKIT;
-  ResetMenuStrip(myWindow,&menuTerminal);
+  SetMenuStrip(myWindow,&menuTerminal);
 }
 
 /**
@@ -248,7 +248,7 @@ void menu_update_baud_rate(long baud_rate)
       item115200.Flags=ITEMTEXT|ITEMENABLED|HIGHCOMP|CHECKIT|CHECKED;
       break;
     }
-  ResetMenuStrip(myWindow,&menuTerminal);
+  SetMenuStrip(myWindow,&menuTerminal);
 }
 
 /* Add our menu to the menustrip */


### PR DESCRIPTION
Avoid hangs on WaitIO in some circumstances and replaceResetMenuStrip with SetMenuStrip for 1.3.x compat.