### PR TITLE
Create preferences file if it does not exist.

### DIFF
--- a/src/prefs.c
+++ b/src/prefs.c
@@ -44,7 +44,11 @@ void prefs_load(void)
 {
   fileHandle=Open(PREFS_FILE,MODE_OLDFILE);
   if (fileHandle==0)
+  {
+    fileHandle=Open(PREFS_FILE,MODE_NEWFILE);
+    Close(fileHandle);
     prefs_set_defaults();
+  }
   else
     {
       Read(fileHandle,&config,sizeof(config));


### PR DESCRIPTION
If we don't get a file handle with MODE_OLDFILE create an empty file
with MODE_NEWFILE and then set the default preferences. This avoids
a bug I found where running PLATOTerm on a real floppy or hard disk
(instead of a mapped directory) would never create a preferences file.